### PR TITLE
Add Jest setup and jsdom test for loadContent

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -986,7 +986,9 @@ const projectData = [
   // Add more objects for additional projectData here
 ];
 
-loadContent(projectData);
+if (!(typeof process !== 'undefined' && process.env.JEST_WORKER_ID)) {
+  loadContent(projectData);
+}
 
 function loadContent(projectData) {
   const buildTemplate = (template, data) => {
@@ -1148,3 +1150,7 @@ async function getRepoList() {
 // console.log(repoList[i].name);
 // }
 // })();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports.loadContent = loadContent;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pranav-portfolio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/loadContent.test.js
+++ b/tests/loadContent.test.js
@@ -1,0 +1,28 @@
+const { JSDOM } = require('jsdom');
+const { loadContent } = require('../js/main');
+
+describe('loadContent', () => {
+  beforeEach(() => {
+    const dom = new JSDOM('<div class="project-data"></div><div class="navigation"></div><div class="arrow-right"></div><div class="arrow-left"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.$ = () => ({
+      ready: (fn) => fn(),
+      click: jest.fn(),
+      collapse: jest.fn(),
+      toggleClass: jest.fn(),
+    });
+    global.gsap = { to: jest.fn() };
+    global.VanillaTilt = { init: jest.fn() };
+  });
+
+  test('creates project cards for provided data', () => {
+    const data = [
+      { title: 'One', techStack: [], srcURL: '', thumbnail: '', description: '' },
+      { title: 'Two', techStack: [], srcURL: '', thumbnail: '', description: '' }
+    ];
+    loadContent(data);
+    const cards = document.querySelectorAll('.project-card');
+    expect(cards.length).toBe(data.length);
+  });
+});


### PR DESCRIPTION
## Summary
- initialize npm project and add jest test script
- disable loadContent auto-run during tests
- expose loadContent via `module.exports`
- add test verifying project cards creation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7a92078832e926d9da6d1e3a328