### PR TITLE
Fix spelling in license comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,7 +835,7 @@
                           >Pranav Deshpande</a
                         >
                       </p>
-                      <!-- This website is licenced by Pranav Deshpande,
+                      <!-- This website is licensed by Pranav Deshpande,
                       You are free to: Share and Adapt. You must give appropriate credit, you may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. -->
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- fix typo 'licenced' -> 'licensed' in index.html

## Testing
- `grep -n "licensed" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_683fb7a1f450832e85d8f84a02e1910d