### PR TITLE
Fix link shortning typo

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -921,7 +921,7 @@ const projectData = [
     subTitle: "Here you have full control over your links.",
     thumbnail: "../img/thumbnails/cutlink-thumbnail.png",
     description:
-      "CutLink is a modern and user-friendly web application built with React and Material UI. Our platform offers a complete solution for link shortening. With CutLink, you can create short, branded links that are easy to share. Try CutLink today and experience the power of a smarter link shortning platform!",
+      "CutLink is a modern and user-friendly web application built with React and Material UI. Our platform offers a complete solution for link shortening. With CutLink, you can create short, branded links that are easy to share. Try CutLink today and experience the power of a smarter link shortening platform!",
     techStack: ["React", "MUI"],
     srcURL: "",
   },


### PR DESCRIPTION
## Summary
- correct typo in CutLink project description in `js/main.js`

## Testing
- `grep -n shortning -n js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_683fb79eb298832e84b2f40c8cdfea32