### PR TITLE
Add theme toggle for light mode

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2058,3 +2058,27 @@ footer .support ul li a:hover {
 .blog-content {
   margin: 0;
 }
+
+/* Theme Toggle Button */
+.theme-toggle {
+  background: none;
+  border: none;
+  color: #ffffff;
+  margin-left: 15px;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.theme-toggle:hover {
+  color: #68d372;
+}
+
+/* Light mode */
+body.light-mode {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+body.light-mode img,
+body.light-mode video {
+  filter: invert(1) hue-rotate(180deg);
+}

--- a/index.html
+++ b/index.html
@@ -192,6 +192,9 @@
               <i class="fa-solid fa-cloud-arrow-down fa-lg"></i>Resume
             </button></a
           >
+          <button id="theme-toggle" class="theme-toggle noselect" type="button">
+            <i class="fa-solid fa-moon"></i>
+          </button>
         </div>
       </div>
       <div class="scroll-progress-track">

--- a/js/main.js
+++ b/js/main.js
@@ -1169,3 +1169,28 @@ async function getRepoList() {
 // console.log(repoList[i].name);
 // }
 // })();
+
+// Theme toggle
+function toggleTheme() {
+  const body = document.body;
+  body.classList.toggle("light-mode");
+  const isLight = body.classList.contains("light-mode");
+  localStorage.setItem("theme", isLight ? "light" : "dark");
+  const icon = document.querySelector("#theme-toggle i");
+  if (icon) {
+    icon.classList.toggle("fa-moon", !isLight);
+    icon.classList.toggle("fa-sun", isLight);
+  }
+}
+
+(function () {
+  const saved = localStorage.getItem("theme");
+  if (saved === "light") {
+    document.body.classList.add("light-mode");
+  }
+  const icon = document.querySelector("#theme-toggle i");
+  if (icon && document.body.classList.contains("light-mode")) {
+    icon.classList.remove("fa-moon");
+    icon.classList.add("fa-sun");
+  }
+})();


### PR DESCRIPTION
## Summary
- add a theme toggle button in the navbar
- style theme toggle and apply filter-based light mode
- implement toggleTheme() in JS with persistence

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b2f5e73c832e8e9b26fc954ba0ee